### PR TITLE
Update tab color to factor light and dark modes

### DIFF
--- a/core/extensions/layout/style.css
+++ b/core/extensions/layout/style.css
@@ -34,6 +34,16 @@
   );
 }
 
+.tab-container button {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  appearance: none;
+border: none;
+outline: none;
+}
+
 .tab-container:not(.current) {
   --in-top: 2px;
   --in-bottom: 3px;
@@ -48,14 +58,8 @@
 }
 
 .tab {
-  appearance: none;
-  border: none;
   padding: 0 calc(2.5 * 12px) 0 calc(0.5 * 12px);
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
   background: var(--col-bg-shadow-soft);
-  outline: none;
 }
 
 .tab-container.current .tab,
@@ -74,10 +78,7 @@
 }
 
 .tab-container .close-button {
-  appearance: none;
-  border: none;
   padding: none;
-  outline: none;
   position: absolute;
   top: calc(0.5 * 12px);
   right: calc(0.5 * 12px);
@@ -85,6 +86,7 @@
   height: calc(1.5 * 12px);
   line-height: calc(1.5 * 12px);
   text-align: center;
+  background: var(--col-bg-shadow-soft);
 }
 
 .tab-container:not(.current):not(:hover) .close-button {


### PR DESCRIPTION
Updates the styling for editor tab and close buttons to account for light and dark mode 

Before:
<img width="276" alt="Screenshot 2023-10-07 at 8 24 48 PM" src="https://github.com/mindofmatthew/text.management/assets/10532399/f0d2baa9-dad9-4725-a63d-725a1a955d64">

After: 
<img width="266" alt="Screenshot 2023-10-07 at 8 23 43 PM" src="https://github.com/mindofmatthew/text.management/assets/10532399/2e63aee2-580e-4c84-afa1-9ed01fe3378d">
