### PR TITLE
Add button to open a new tab

### DIFF
--- a/app/desktop/src/ipc.ts
+++ b/app/desktop/src/ipc.ts
@@ -11,6 +11,7 @@ export interface ToMainChannels {
   evaluation: string;
   restart: undefined;
   openTidalSettings: undefined;
+  newTab: undefined;
 }
 
 export interface ToRendererChannels {

--- a/app/desktop/src/main/index.ts
+++ b/app/desktop/src/main/index.ts
@@ -90,6 +90,12 @@ const createWindow = () => {
     );
 
     listeners.push(
+      listen("newTab", () => {
+        filesystem.loadDoc();
+      })
+    )
+
+    listeners.push(
       listen("requestClose", async ({ id }) => {
         let document = filesystem.getDoc(id);
 

--- a/app/desktop/src/preload/index.ts
+++ b/app/desktop/src/preload/index.ts
@@ -60,6 +60,8 @@ const ElectronAPI = {
 
   requestClose: (id: string) => send("requestClose", { id }),
 
+  newTab: () => send("newTab", undefined),
+
   onClose: listen("close"),
 
   onSetCurrent: listen("setCurrent"),

--- a/app/desktop/src/renderer/main.ts
+++ b/app/desktop/src/renderer/main.ts
@@ -31,7 +31,7 @@ const background: string | null = null;
 
 export class Editor {
   constructor(parent: HTMLElement) {
-    let layout = new LayoutView(parent, api.setCurrent);
+    let layout = new LayoutView(parent, api.setCurrent, api.newTab);
 
     if (background) {
       let canvas = parent.appendChild(document.createElement("iframe"));

--- a/app/web/src/main.ts
+++ b/app/web/src/main.ts
@@ -43,7 +43,7 @@ window.addEventListener("load", () => {
 
 export class Editor {
   constructor(parent: HTMLElement) {
-    let layout = new LayoutView(parent, () => {});
+    let layout = new LayoutView(parent, () => {}, () => {});
     layout.dispatch({
       changes: [
         {

--- a/core/extensions/layout/style.css
+++ b/core/extensions/layout/style.css
@@ -101,3 +101,7 @@ outline: none;
   background: orange;
   color: var(--col-background);
 }
+
+.new-tab-button {
+  background: orange;
+}

--- a/core/extensions/layout/style.css
+++ b/core/extensions/layout/style.css
@@ -78,7 +78,7 @@ outline: none;
 }
 
 .tab-container .close-button {
-  padding: none;
+  padding: 0;
   position: absolute;
   top: calc(0.5 * 12px);
   right: calc(0.5 * 12px);
@@ -103,5 +103,14 @@ outline: none;
 }
 
 .new-tab-button {
-  background: orange;
+  background: var(--col-bg-shadow-soft);
+  border: none;
+  color: inherit;
+  height: 30px;
+  width: 30px;
+  line-height: 30px;
+}
+
+.new-tab-button:hover {
+  background: var(--col-bg-shadow);
 }

--- a/core/extensions/layout/tabbar.ts
+++ b/core/extensions/layout/tabbar.ts
@@ -71,7 +71,6 @@ export class TabBar {
       }
     }
 
-
     // Update tab buttons
     for (let [_, child] of this.children) {
       child.update(tr);

--- a/core/extensions/layout/tabbar.ts
+++ b/core/extensions/layout/tabbar.ts
@@ -6,7 +6,7 @@ import { faPlus, faXmark } from "@fortawesome/free-solid-svg-icons";
 
 export class TabBar {
   readonly dom: HTMLDivElement;
-  readonly newTabButton: NewTabButton;
+  newTabButton: NewTabButton;
 
   private children: Map<string, TabButton> = new Map();
 
@@ -48,6 +48,7 @@ export class TabBar {
     });
 
     this.newTabButton = new NewTabButton(this.parent) 
+    this.dom.appendChild(this.newTabButton.dom);
   }
 
   update(tr: LayoutTransaction) {
@@ -65,11 +66,11 @@ export class TabBar {
         let tab = new TabButton(this.parent, change.view);
         this.children.set(state.id, tab);
         // TODO: This assumes that all added tabs are added to the end
-        this.dom.appendChild(tab.dom);
+        // but before the new tab button
+        this.dom.insertBefore(tab.dom, this.newTabButton.dom)
       }
     }
 
-    this.dom.appendChild(this.newTabButton.dom);
 
     // Update tab buttons
     for (let [_, child] of this.children) {
@@ -87,9 +88,10 @@ class NewTabButton {
     this.dom.append(
       ...icon(faPlus, { attributes: { "aria-hidden": "true" } }).node
     );
+
     this.dom.addEventListener("click", () => {
       this.parent.newTab();
-    })
+    });
   }
 }
 

--- a/core/extensions/layout/tabbar.ts
+++ b/core/extensions/layout/tabbar.ts
@@ -84,6 +84,7 @@ class NewTabButton {
   constructor(private parent: LayoutView) {
     this.dom = document.createElement("button");
     this.dom.classList.add("new-tab-button");
+    this.dom.setAttribute("aria-label", "New Document");
     this.dom.append(
       ...icon(faPlus, { attributes: { "aria-hidden": "true" } }).node
     );

--- a/core/extensions/layout/tabbar.ts
+++ b/core/extensions/layout/tabbar.ts
@@ -2,10 +2,11 @@ import { LayoutTransaction, TabState, focusCurrent } from "./state";
 import { LayoutView, TabView } from "./view";
 
 import { icon } from "@fortawesome/fontawesome-svg-core";
-import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faXmark } from "@fortawesome/free-solid-svg-icons";
 
 export class TabBar {
   readonly dom: HTMLDivElement;
+  readonly newTabButton: NewTabButton;
 
   private children: Map<string, TabButton> = new Map();
 
@@ -45,6 +46,8 @@ export class TabBar {
         currentButton.focus();
       }
     });
+
+    this.newTabButton = new NewTabButton(this.parent) 
   }
 
   update(tr: LayoutTransaction) {
@@ -66,10 +69,27 @@ export class TabBar {
       }
     }
 
+    this.dom.appendChild(this.newTabButton.dom);
+
     // Update tab buttons
     for (let [_, child] of this.children) {
       child.update(tr);
     }
+  }
+}
+
+class NewTabButton {
+  readonly dom: HTMLButtonElement;
+
+  constructor(private parent: LayoutView) {
+    this.dom = document.createElement("button");
+    this.dom.classList.add("new-tab-button");
+    this.dom.append(
+      ...icon(faPlus, { attributes: { "aria-hidden": "true" } }).node
+    );
+    this.dom.addEventListener("click", () => {
+      this.parent.newTab();
+    })
   }
 }
 

--- a/core/extensions/layout/view.ts
+++ b/core/extensions/layout/view.ts
@@ -19,7 +19,8 @@ export class LayoutView {
 
   constructor(
     parent: HTMLElement,
-    private updateCurrent: (current: string | null) => void
+    private updateCurrent: (current: string | null) => void,
+    public newTab: () => void
   ) {
     this.dom = document.createElement("div");
     this.dom.classList.add("editor-layout");


### PR DESCRIPTION
Adds a `+` button that opens a new tab. Addresses #64 

<img width="461" alt="Screenshot 2023-10-13 at 9 42 55 AM" src="https://github.com/mindofmatthew/text.management/assets/10532399/07a2e8cf-1a57-4113-91d7-3f26dbadccb0">

Test: 
1. Open the editor
2. Click the `+` and verify that a new tab is appended at the end of the tab list with every click
3. Close open tabs that the `+` snaps to the end of the tab list when it shrinks