### PR TITLE
Handle document close properly

### DIFF
--- a/app/desktop/src/main/filesystem.ts
+++ b/app/desktop/src/main/filesystem.ts
@@ -11,6 +11,7 @@ interface DocumentEvents {
   loaded: FileStatus & { doc: Text; version: number };
   status: SavedStatus;
   update: DocumentState;
+  closed: void;
 }
 
 interface FileStatus {
@@ -137,6 +138,11 @@ export class DesktopDocument extends EventEmitter<DocumentEvents> {
     this.content = content;
     this.emit("update", content);
   }
+
+  async close() {
+    // TODO: Better handling to catch save errors, emit additional saves, etc
+    this.emit("closed", undefined);
+  }
 }
 
 interface FilesystemEvents {
@@ -181,6 +187,10 @@ export class Filesystem extends EventEmitter<FilesystemEvents> {
     let id = getID();
     let document = new DesktopDocument(id, path, defaultContent);
     this.docs.set(id, document);
+
+    document.once("closed", () => {
+      this.docs.delete(id);
+    });
 
     this.emit("open", document);
 

--- a/app/desktop/src/main/index.ts
+++ b/app/desktop/src/main/index.ts
@@ -97,36 +97,7 @@ const createWindow = () => {
 
     listeners.push(
       listen("requestClose", async ({ id }) => {
-        let document = filesystem.getDoc(id);
-
-        if (!document) throw Error("Tried to close a non-existent document");
-
-        if (!document.saved) {
-          let { response } = await dialog.showMessageBox(window, {
-            type: "warning",
-            message: "Do you want to save your changes?",
-            buttons: ["Save", "Don't Save", "Cancel"],
-          });
-
-          // Cancelled
-          if (response === 2) return;
-
-          // Save
-          if (response === 0) {
-            if (document.path) {
-              document.save();
-            } else {
-              let { canceled, filePath } = await dialog.showSaveDialog(window);
-
-              if (!canceled && filePath) {
-                document.save(filePath);
-              }
-            }
-          }
-        }
-
-        // We're done here, so close the file
-        send("close", { id });
+        await close({ window, id });
       })
     );
 
@@ -303,6 +274,9 @@ async function close({ window, id }: CloseOptions) {
       }
     }
   }
+
+  // Close document
+  await document.close();
 
   // We're done here, so close the file
   send("close", { id });


### PR DESCRIPTION
Keep track of which documents have been closed so that reopening them doesn't break the UI.

Fixes #69